### PR TITLE
SpanPointMarkDangerousCheck

### DIFF
--- a/slack-lint-annotations/gradle.properties
+++ b/slack-lint-annotations/gradle.properties
@@ -1,6 +1,6 @@
 POM_ARTIFACT_ID=slack-lint-annotations
 # Atomically increment version, not beholden to semver
-VERSION_NAME=00006
+VERSION_NAME=00007
 
 POM_NAME=Slack Lint Annotations
 POM_DESCRIPTION=Slack lint annotations.

--- a/slack-lint-annotations/gradle.properties
+++ b/slack-lint-annotations/gradle.properties
@@ -1,6 +1,6 @@
 POM_ARTIFACT_ID=slack-lint-annotations
 # Atomically increment version, not beholden to semver
-VERSION_NAME=00005
+VERSION_NAME=00006
 
 POM_NAME=Slack Lint Annotations
 POM_DESCRIPTION=Slack lint annotations.

--- a/slack-lint-annotations/src/main/kotlin/slack/lint/annotations/RestrictCallsTo.kt
+++ b/slack-lint-annotations/src/main/kotlin/slack/lint/annotations/RestrictCallsTo.kt
@@ -17,14 +17,14 @@ package slack.lint.annotations
 
 import java.lang.annotation.Inherited
 import kotlin.annotation.AnnotationRetention.RUNTIME
-import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.FUNCTION
 
 /**
  * Annotation representing a function or property that should not be called outside of a given
  * [scope]. Similar to androidx's `RestrictTo` annotation but just for calls.
  */
 @Inherited
-@Target(CLASS)
+@Target(FUNCTION)
 @Retention(RUNTIME)
 annotation class RestrictCallsTo(
   /**

--- a/slack-lint-annotations/src/main/kotlin/slack/lint/annotations/RestrictCallsTo.kt
+++ b/slack-lint-annotations/src/main/kotlin/slack/lint/annotations/RestrictCallsTo.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint.annotations
+
+import java.lang.annotation.Inherited
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+
+/**
+ * Annotation representing a function or property that should not be called outside of a given
+ * [scope]. Similar to androidx's `RestrictTo` annotation but just for calls.
+ */
+@Inherited
+@Target(CLASS)
+@Retention(RUNTIME)
+annotation class RestrictCallsTo(
+  /**
+   * The target scope. Only file is supported for now, toe-hold left for possible future scopes.
+   */
+  val scope: Int = FILE
+) {
+  companion object {
+    const val FILE = 0
+  }
+}

--- a/slack-lint/gradle.properties
+++ b/slack-lint/gradle.properties
@@ -1,6 +1,6 @@
 POM_ARTIFACT_ID=slack-lint
 # Atomically increment version, not beholden to semver
-VERSION_NAME=00058
+VERSION_NAME=00059
 
 POM_NAME=Slack Lint
 POM_DESCRIPTION=Slack lint checks.

--- a/slack-lint/src/main/java/slack/lint/RestrictCallsToDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/RestrictCallsToDetector.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UFile
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.getContainingUFile
+import org.jetbrains.uast.resolveToUElement
+import org.jetbrains.uast.toUElementOfType
+import slack.lint.util.sourceImplementation
+
+class RestrictCallsToDetector : Detector(), SourceCodeScanner {
+
+  companion object {
+    val ISSUE: Issue = Issue.create(
+      "RestrictCallsTo",
+      "Methods annotated with @RestrictedCallsTo should only be called from the specified scope.",
+      """
+          This method is intended to only be called from the specified scope despite it being \
+          public. This could be due to its use in an interface or similar. Overrides are still \
+          ok.
+      """,
+      Category.CORRECTNESS,
+      6,
+      Severity.ERROR,
+      sourceImplementation<RestrictCallsToDetector>()
+    )
+
+    private const val RESTRICT_CALLS_TO_ANNOTATION = "slack.lint.annotations.RestrictCallsTo"
+  }
+
+  override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext) = object : UElementHandler() {
+
+    @Suppress("UNUSED_VARIABLE") // Toe-hold for now until we support other scopes
+    override fun visitCallExpression(node: UCallExpression) {
+      val method = node.resolveToUElement() as? UMethod ?: return
+
+      val (restrictCallsTo, annotatedMethod) = method.superMethodSequence()
+        .mapNotNull { superMethod ->
+          superMethod.findAnnotation(RESTRICT_CALLS_TO_ANNOTATION)?.let {
+            it to superMethod
+          }
+        }
+        .firstOrNull() ?: return
+
+      val containingFile = annotatedMethod.getContainingUFile() ?: return
+      val callingFile = node.getContainingUFile() ?: return
+      if (!callingFile.isSameAs(containingFile)) {
+        context.report(
+          ISSUE,
+          node,
+          context.getLocation(node),
+          ISSUE.getBriefDescription(TextFormat.TEXT)
+        )
+      }
+    }
+
+    private fun UMethod.superMethodSequence(): Sequence<UMethod> {
+      return generateSequence(this) {
+        if (context.evaluator.isOverride(it)) {
+          // Note this doesn't try to check multiple interfaces, but we can fix that in the future
+          // if it matters
+          it.findSuperMethods()[0].toUElementOfType()
+        } else {
+          null
+        }
+      }
+    }
+  }
+
+  // UFile isn't inherently comparable, so package and simple name are close enough for us.
+  private fun UFile.isSameAs(other: UFile): Boolean {
+    return this.packageName == other.packageName && this.sourcePsi.name == other.sourcePsi.name
+  }
+}

--- a/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -27,6 +27,7 @@ import slack.lint.mocking.DoNotMockMockDetector
 import slack.lint.mocking.ErrorProneDoNotMockDetector
 import slack.lint.retrofit.RetrofitUsageDetector
 import slack.lint.rx.RxSubscribeOnMainDetector
+import slack.lint.text.SpanPointMarkDangerousCheckDetector
 
 @AutoService(IssueRegistry::class)
 class SlackIssueRegistry : IssueRegistry() {
@@ -62,5 +63,6 @@ class SlackIssueRegistry : IssueRegistry() {
     InjectInJavaDetector.ISSUE,
     RetrofitUsageDetector.ISSUE,
     RestrictCallsToDetector.ISSUE,
+    SpanPointMarkDangerousCheckDetector.ISSUE,
   )
 }

--- a/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
+++ b/slack-lint/src/main/java/slack/lint/SlackIssueRegistry.kt
@@ -61,5 +61,6 @@ class SlackIssueRegistry : IssueRegistry() {
     *RedactedUsageDetector.ISSUES,
     InjectInJavaDetector.ISSUE,
     RetrofitUsageDetector.ISSUE,
+    RestrictCallsToDetector.ISSUE,
   )
 }

--- a/slack-lint/src/main/java/slack/lint/text/SpanPointMarkDangerousCheckDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/text/SpanPointMarkDangerousCheckDetector.kt
@@ -1,0 +1,102 @@
+package slack.lint.text
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Location
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.XmlContext
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiType
+import org.jetbrains.uast.UBinaryExpression
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.sourcePsiElement
+import org.w3c.dom.Element
+import slack.lint.retrofit.RetrofitUsageDetector
+import slack.lint.rx.RxSubscribeOnMainDetector
+import slack.lint.util.removeNode
+import slack.lint.util.sourceImplementation
+import java.util.regex.Pattern
+
+class SpanPointMarkDangerousCheckDetector : Detector(), SourceCodeScanner {
+
+    companion object {
+        private fun Implementation.toIssue() = Issue.create(
+            id = "SpanPointMarkDangerousCheck",
+            briefDescription = "my desc.",
+            explanation = """
+        Spans flags can have priority or other bits set. Check using `currentFlag and Spanned.SPAN_POINT_MARK_MASK == desiredFlag` 
+      """,
+            category = Category.CORRECTNESS,
+            priority = 4,
+            severity = Severity.ERROR,
+            implementation = this
+        )
+
+        val ISSUE = sourceImplementation<SpanPointMarkDangerousCheckDetector>().toIssue()
+
+        private const val MARK_POINT =
+            "(Spanned.)?(INCLUSIVE_INCLUSIVE|INCLUSIVE_EXCLUSIVE|EXCLUSIVE_INCLUSIVE|EXCLUSIVE_EXCLUSIVE)"
+        private const val FLAG_WITHOUT_MASK = "((?!\\b+and\\s+SPAN_POINT_MARK_MASK\\b).)*"
+        private const val EQUALITY_OPERATOR = "((==)|(\\!=))"
+        val regex = Regex(
+            "(^($FLAG_WITHOUT_MASK)\\s*$EQUALITY_OPERATOR\\s*($MARK_POINT)$)|" +
+                    "(^($MARK_POINT)\\s*$EQUALITY_OPERATOR\\s*($FLAG_WITHOUT_MASK)$)"
+        )
+    }
+
+    override fun getApplicableUastTypes() = listOf(UBinaryExpression::class.java)
+
+    /**
+     *
+     * For next time:
+     *
+     * Figure out how to only match the smallest binary expression that matches for each line:
+     * Currently it matches twice.
+     *
+     * Matches are [0 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()) || Spanned.x(), 1 null, 2 null, 3 null, 4 null, 5 null, 6 null, 7 null, 8 null, 9 null, 10 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()) || Spanned.x(), 11 Spanned.INCLUSIVE_INCLUSIVE, 12 Spanned., 13 INCLUSIVE_INCLUSIVE, 14 !=, 15 null, 16 !=, 17 spanned.getSpanFlags(Object()) || Spanned.x(), 18 )]
+        Matches are [0 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()), 1 null, 2 null, 3 null, 4 null, 5 null, 6 null, 7 null, 8 null, 9 null, 10 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()), 11 Spanned.INCLUSIVE_INCLUSIVE, 12 Spanned., 13 INCLUSIVE_INCLUSIVE, 14 !=, 15 null, 16 !=, 17 spanned.getSpanFlags(Object()), 18 )]
+
+     */
+
+    override fun createUastHandler(context: JavaContext): UElementHandler {
+        System.out.println("regex" + regex.toString())
+        return object : UElementHandler() {
+            override fun visitBinaryExpression(node: UBinaryExpression) {
+                val text = node.sourcePsi?.text ?: return
+                val match = regex.find(text) ?: return
+                System.out.println("Matches are " + match.groups.mapIndexed { i, group -> "$i ${group?.value}" })
+                val markPoint = (match.groups[7] ?: match.groups[11])!!.value
+                val flagWithoutMask = (match.groups[2] ?: match.groups[10])!!.value
+
+                /*
+                Matches are [0 spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE, 1 spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE, 2 spanned.getSpanFlags(Object()) , 3  , 4 !=, 5 null, 6 !=, 7 Spanned.INCLUSIVE_INCLUSIVE, 8 Spanned., 9 INCLUSIVE_INCLUSIVE, 10 null, 11 null, 12 null, 13 null, 14 null, 15 null, 16 null, 17 null, 18 null]
+                 */
+                val equality = (match.groups[5] ?: match.groups[6] ?: match.groups[15] ?: match.groups[16])!!.value
+                context.report(
+                    ISSUE,
+                    context.getLocation(node),
+                    "Do not check against $markPoint directly. " +
+                            "Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags.",
+                    LintFix.create()
+                        .replace()
+                        .name("Use bitwise mask")
+                        .text(match.groups[0]!!.value)
+                        .with("($flagWithoutMask) and Spanned.SPAN_POINT_MARK_MASK $equality $markPoint")
+                        .build()
+                )
+            }
+        }
+    }
+
+}

--- a/slack-lint/src/main/java/slack/lint/text/SpanPointMarkDangerousCheckDetector.kt
+++ b/slack-lint/src/main/java/slack/lint/text/SpanPointMarkDangerousCheckDetector.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package slack.lint.text
 
 import com.android.tools.lint.client.api.UElementHandler
@@ -7,96 +22,101 @@ import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
 import com.android.tools.lint.detector.api.LintFix
-import com.android.tools.lint.detector.api.Location
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
-import com.android.tools.lint.detector.api.XmlContext
-import com.intellij.psi.JavaElementVisitor
-import com.intellij.psi.PsiMethod
-import com.intellij.psi.PsiMethodCallExpression
-import com.intellij.psi.PsiType
+import com.android.tools.lint.detector.api.UastLintUtils
 import org.jetbrains.uast.UBinaryExpression
-import org.jetbrains.uast.UClass
-import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UExpression
-import org.jetbrains.uast.UMethod
-import org.jetbrains.uast.sourcePsiElement
-import org.w3c.dom.Element
-import slack.lint.retrofit.RetrofitUsageDetector
-import slack.lint.rx.RxSubscribeOnMainDetector
-import slack.lint.util.removeNode
+import org.jetbrains.uast.UReferenceExpression
+import org.jetbrains.uast.UastBinaryOperator
+import org.jetbrains.uast.tryResolve
+import slack.lint.text.SpanPointMarkDangerousCheckDetector.Companion.ISSUE
 import slack.lint.util.sourceImplementation
-import java.util.regex.Pattern
 
+/**
+ * Checks for SpanPointMarkDangerousCheck. See [ISSUE].
+ */
 class SpanPointMarkDangerousCheckDetector : Detector(), SourceCodeScanner {
 
+  companion object {
+    private fun Implementation.toIssue() = Issue.create(
+      id = "SpanPointMarkDangerousCheck",
+      briefDescription = "Check Span Flags Using Bitmask",
+      explanation =
+      "Spans flags can have priority or other bits set. " +
+        "Ensure that Span flags are checked using " +
+        "`currentFlag and Spanned.SPAN_POINT_MARK_MASK == desiredFlag` " +
+        "rather than just `currentFlag == desiredFlag`",
+      category = Category.CORRECTNESS,
+      priority = 4,
+      severity = Severity.ERROR,
+      implementation = this
+    )
+
+    val ISSUE = sourceImplementation<SpanPointMarkDangerousCheckDetector>().toIssue()
+  }
+
+  override fun getApplicableUastTypes() = listOf(UBinaryExpression::class.java)
+
+  override fun createUastHandler(context: JavaContext): UElementHandler {
+    return ReportingHandler(context)
+  }
+
+  /**
+   * Reports violations of SpanPointMarkDangerousCheck.
+   */
+  private class ReportingHandler(private val context: JavaContext) : UElementHandler() {
     companion object {
-        private fun Implementation.toIssue() = Issue.create(
-            id = "SpanPointMarkDangerousCheck",
-            briefDescription = "my desc.",
-            explanation = """
-        Spans flags can have priority or other bits set. Check using `currentFlag and Spanned.SPAN_POINT_MARK_MASK == desiredFlag` 
-      """,
-            category = Category.CORRECTNESS,
-            priority = 4,
-            severity = Severity.ERROR,
-            implementation = this
-        )
-
-        val ISSUE = sourceImplementation<SpanPointMarkDangerousCheckDetector>().toIssue()
-
-        private const val MARK_POINT =
-            "(Spanned.)?(INCLUSIVE_INCLUSIVE|INCLUSIVE_EXCLUSIVE|EXCLUSIVE_INCLUSIVE|EXCLUSIVE_EXCLUSIVE)"
-        private const val FLAG_WITHOUT_MASK = "((?!\\b+and\\s+SPAN_POINT_MARK_MASK\\b).)*"
-        private const val EQUALITY_OPERATOR = "((==)|(\\!=))"
-        val regex = Regex(
-            "(^($FLAG_WITHOUT_MASK)\\s*$EQUALITY_OPERATOR\\s*($MARK_POINT)$)|" +
-                    "(^($MARK_POINT)\\s*$EQUALITY_OPERATOR\\s*($FLAG_WITHOUT_MASK)$)"
-        )
+      private const val SPANNED_CLASS = "android.text.Spanned"
+      private val markPointFields = setOf(
+        "$SPANNED_CLASS.SPAN_INCLUSIVE_INCLUSIVE",
+        "$SPANNED_CLASS.SPAN_INCLUSIVE_EXCLUSIVE",
+        "$SPANNED_CLASS.SPAN_EXCLUSIVE_INCLUSIVE",
+        "$SPANNED_CLASS.SPAN_EXCLUSIVE_EXCLUSIVE",
+      )
+      private const val MASK_CLASS = "$SPANNED_CLASS.SPAN_POINT_MARK_MASK"
     }
 
-    override fun getApplicableUastTypes() = listOf(UBinaryExpression::class.java)
-
-    /**
-     *
-     * For next time:
-     *
-     * Figure out how to only match the smallest binary expression that matches for each line:
-     * Currently it matches twice.
-     *
-     * Matches are [0 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()) || Spanned.x(), 1 null, 2 null, 3 null, 4 null, 5 null, 6 null, 7 null, 8 null, 9 null, 10 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()) || Spanned.x(), 11 Spanned.INCLUSIVE_INCLUSIVE, 12 Spanned., 13 INCLUSIVE_INCLUSIVE, 14 !=, 15 null, 16 !=, 17 spanned.getSpanFlags(Object()) || Spanned.x(), 18 )]
-        Matches are [0 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()), 1 null, 2 null, 3 null, 4 null, 5 null, 6 null, 7 null, 8 null, 9 null, 10 Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()), 11 Spanned.INCLUSIVE_INCLUSIVE, 12 Spanned., 13 INCLUSIVE_INCLUSIVE, 14 !=, 15 null, 16 !=, 17 spanned.getSpanFlags(Object()), 18 )]
-
-     */
-
-    override fun createUastHandler(context: JavaContext): UElementHandler {
-        System.out.println("regex" + regex.toString())
-        return object : UElementHandler() {
-            override fun visitBinaryExpression(node: UBinaryExpression) {
-                val text = node.sourcePsi?.text ?: return
-                val match = regex.find(text) ?: return
-                System.out.println("Matches are " + match.groups.mapIndexed { i, group -> "$i ${group?.value}" })
-                val markPoint = (match.groups[7] ?: match.groups[11])!!.value
-                val flagWithoutMask = (match.groups[2] ?: match.groups[10])!!.value
-
-                /*
-                Matches are [0 spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE, 1 spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE, 2 spanned.getSpanFlags(Object()) , 3  , 4 !=, 5 null, 6 !=, 7 Spanned.INCLUSIVE_INCLUSIVE, 8 Spanned., 9 INCLUSIVE_INCLUSIVE, 10 null, 11 null, 12 null, 13 null, 14 null, 15 null, 16 null, 17 null, 18 null]
-                 */
-                val equality = (match.groups[5] ?: match.groups[6] ?: match.groups[15] ?: match.groups[16])!!.value
-                context.report(
-                    ISSUE,
-                    context.getLocation(node),
-                    "Do not check against $markPoint directly. " +
-                            "Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags.",
-                    LintFix.create()
-                        .replace()
-                        .name("Use bitwise mask")
-                        .text(match.groups[0]!!.value)
-                        .with("($flagWithoutMask) and Spanned.SPAN_POINT_MARK_MASK $equality $markPoint")
-                        .build()
-                )
-            }
-        }
+    override fun visitBinaryExpression(node: UBinaryExpression) {
+      if (node.operator is UastBinaryOperator.ComparisonOperator) {
+        checkExpressions(node, node.leftOperand, node.rightOperand)
+        checkExpressions(node, node.rightOperand, node.leftOperand)
+      }
     }
 
+    fun checkExpressions(node: UBinaryExpression, markPointCheck: UExpression, maskCheck: UExpression) {
+      if (matchesMarkPoint(markPointCheck) && !matchesMask(maskCheck)) {
+        context.report(
+          ISSUE,
+          context.getLocation(node),
+          "Do not check against ${markPointCheck.sourcePsi?.text} directly. " +
+            "Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags.",
+          LintFix.create()
+            .replace()
+            .name("Use bitwise mask")
+            .text(maskCheck.sourcePsi?.text)
+            .with("((${maskCheck.sourcePsi?.text}) and $MASK_CLASS)")
+            .build()
+        )
+      }
+    }
+
+    fun matchesMarkPoint(expression: UExpression): Boolean {
+      return markPointFields.contains(getQualifiedName(expression))
+    }
+
+    fun matchesMask(expression: UExpression): Boolean {
+      return if (expression is UBinaryExpression) {
+        getQualifiedName(expression.leftOperand) == MASK_CLASS || getQualifiedName(expression.rightOperand) == MASK_CLASS
+      } else {
+        false
+      }
+    }
+
+    fun getQualifiedName(expression: UExpression): String? {
+      return (expression as? UReferenceExpression)?.referenceNameElement?.uastParent?.tryResolve()?.let {
+        UastLintUtils.getQualifiedName(it)
+      }
+    }
+  }
 }

--- a/slack-lint/src/test/java/slack/lint/RestrictCallsToDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/RestrictCallsToDetectorTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package slack.lint
+
+import org.junit.Test
+
+class RestrictCallsToDetectorTest : BaseSlackLintTest() {
+
+  private companion object {
+    private val restrictCallsTo = kotlin(
+      """
+        package slack.lint.annotations
+        import java.lang.annotation.Inherited
+
+        @Inherited
+        annotation class RestrictCallsTo(val scope: Int) {
+          companion object {
+            const val FILE = 0
+          }
+        }
+      """
+    ).indented()
+  }
+
+  override fun getDetector() = RestrictCallsToDetector()
+  override fun getIssues() = listOf(RestrictCallsToDetector.ISSUE)
+
+  @Test
+  fun smokeTest() {
+    lint()
+      .files(
+        restrictCallsTo,
+        kotlin(
+          """
+          package foo
+
+          import slack.lint.annotations.RestrictCallsTo
+          import slack.lint.annotations.RestrictCallsTo.Companion.FILE
+
+          interface MyApi {
+            fun example()
+
+            @RestrictCallsTo(FILE)
+            fun annotatedExample()
+          }
+
+          class SameFile {
+            fun doStuffWith(api: MyApi) {
+              // This is ok
+              api.example()
+              api.annotatedExample()
+            }
+          }
+
+          class MyApiImpl : MyApi {
+            override fun example() {
+              annotatedExample()
+            }
+
+            // Note this is not annotated, ensures we check up the hierarchy
+            override fun annotatedExample() {
+              println("Hello")
+            }
+          }
+        """
+        ).indented(),
+        kotlin(
+          """
+          package foo
+
+          class DifferentFile {
+            fun doStuffWith(api: MyApi) {
+              // This is ok
+              api.example()
+              // This is not
+              api.annotatedExample()
+            }
+          }
+
+          class MyApiImpl2 : MyApi {
+            override fun example() {
+              // Not ok
+              annotatedExample()
+            }
+
+            // Still ok
+            override fun annotatedExample() {
+              println("Hello")
+            }
+
+            fun backdoor() {
+              // Backdoors don't work either! This isn't annotated on the impl but we check the
+              // original overridden type.
+              MyApiImpl().annotatedExample()
+            }
+          }
+        """
+        ).indented(),
+      )
+      .allowCompilationErrors(false)
+      .run()
+      .expect(
+        """
+        src/foo/DifferentFile.kt:8: Error: Methods annotated with @RestrictedCallsTo should only be called from the specified scope. [RestrictCallsTo]
+            api.annotatedExample()
+            ~~~~~~~~~~~~~~~~~~~~~~
+        src/foo/DifferentFile.kt:15: Error: Methods annotated with @RestrictedCallsTo should only be called from the specified scope. [RestrictCallsTo]
+            annotatedExample()
+            ~~~~~~~~~~~~~~~~~~
+        src/foo/DifferentFile.kt:26: Error: Methods annotated with @RestrictedCallsTo should only be called from the specified scope. [RestrictCallsTo]
+            MyApiImpl().annotatedExample()
+            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        3 errors, 0 warnings
+        """.trimIndent()
+      )
+  }
+}

--- a/slack-lint/src/test/java/slack/lint/text/SpanPointMarkDangerousCheckDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/text/SpanPointMarkDangerousCheckDetectorTest.kt
@@ -1,165 +1,180 @@
+/*
+ * Copyright (C) 2021 Slack Technologies, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package slack.lint.text
 
 import org.intellij.lang.annotations.Language
-import org.junit.Assert.*
 import org.junit.Test
 import slack.lint.BaseSlackLintTest
-import slack.lint.rx.RxSubscribeOnMainDetector
-import slack.lint.rx.rxJavaJar3
 
+/**
+ * Tests [SpanPointMarkDangerousCheckDetector].
+ */
 class SpanPointMarkDangerousCheckDetectorTest : BaseSlackLintTest() {
 
-    override fun getDetector() = SpanPointMarkDangerousCheckDetector()
-    override fun getIssues() = listOf(SpanPointMarkDangerousCheckDetector.ISSUE)
+  override fun getDetector() = SpanPointMarkDangerousCheckDetector()
+  override fun getIssues() = listOf(SpanPointMarkDangerousCheckDetector.ISSUE)
 
-    @Test
-    fun `visitBinaryExpression - given violating file with equality and flag on right - creates error and fix`() {
-        @Language("kotlin")
-        val testFile = kotlin(
-            """
-                package slack.text
-        
-              import android.text.Spanned
-        
-              class MyClass {
-                  fun doCheck(spanned: Spanned): Boolean {
-                    return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                  }
-              }
-            """
-        ).indented()
-        lint()
-            .files(testFile)
-            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
-            .run()
-            .expect(
-                """
-                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
-                      return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                1 errors, 0 warnings
-                """.trimIndent()
-            )
-            .expectFixDiffs(
-                """
-                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
-                @@ -7 +7
-                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                """.trimIndent()
-            )
-    }
-    @Test
-    fun `visitBinaryExpression - given violating file with equality and flag on left - creates error and fix`() {
-        @Language("kotlin")
-        val testFile = kotlin(
-            """
-                package slack.text
-        
-              import android.text.Spanned
-        
-              class MyClass {
-                  fun doCheck(spanned: Spanned): Boolean {
-                    return Spanned.INCLUSIVE_INCLUSIVE == spanned.getSpanFlags(Object()) || Spanned.x()
-                  }
-              }
-            """
-        ).indented()
-        lint()
-            .files(testFile)
-            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
-            .run()
-            .expect(
-                """
-                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
-                      return Spanned.INCLUSIVE_INCLUSIVE == spanned.getSpanFlags(Object()) || Spanned.x()
-                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                1 errors, 0 warnings
-                """.trimIndent()
-            )
-            .expectFixDiffs(
-                """
-                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
-                @@ -7 +7
-                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                """.trimIndent()
-            )
-    }
+  private val androidTextStubs = kotlin(
+    """
+        package android.text
 
-    @Test
-    fun `visitBinaryExpression - given violating file with inequality and flag on right - creates error and fix`() {
-        @Language("kotlin")
-        val testFile = kotlin(
-            """
-                package slack.text
-        
-              import android.text.Spanned
-        
-              class MyClass {
-                  fun doCheck(spanned: Spanned): Boolean {
-                    return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                  }
-              }
-            """
-        ).indented()
-        lint()
-            .files(testFile)
-            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
-            .run()
-            .expect(
-                """
-                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
-                      return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                1 errors, 0 warnings
-                """.trimIndent()
-            )
-            .expectFixDiffs(
-                """
-                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
-                @@ -7 +7
-                -       return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                """.trimIndent()
-            )
-    }
+        object Spanned {
+            const val SPAN_INCLUSIVE_INCLUSIVE = 1
+            const val SPAN_INCLUSIVE_EXCLUSIVE = 2
+            const val SPAN_EXCLUSIVE_INCLUSIVE = 3
+            const val SPAN_EXCLUSIVE_EXCLUSIVE = 4
+            const val SPAN_POINT_MARK_MASK = 0xFF
+        }
+      """
+  ).indented()
 
-    @Test
-    fun `visitBinaryExpression - given violating file with inequality and flag on left - creates error and fix`() {
-        @Language("kotlin")
-        val testFile = kotlin(
-            """
+  @Test
+  fun `visitBinaryExpression - given conforming expression - has clean report`() {
+    @Language("kotlin")
+    val testFile = kotlin(
+      """
                 package slack.text
-        
+
               import android.text.Spanned
-        
+
               class MyClass {
-                  fun doCheck(spanned: Spanned): Boolean {
-                    return Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()) || Spanned.x()
+                  fun doCheckCorrectly(spanned: Spanned): Boolean {
+                    return spanned.getSpanFlags(Object()) and Spanned.SPAN_POINT_MARK_MASK == Spanned.SPAN_INCLUSIVE_INCLUSIVE
                   }
               }
             """
-        ).indented()
-        lint()
-            .files(testFile)
-            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
-            .run()
-            .expect(
-                """
-                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
-                      return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                1 errors, 0 warnings
-                """.trimIndent()
-            )
-            .expectFixDiffs(
-                """
-                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
-                @@ -7 +7
-                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
-                """.trimIndent()
-            )
-    }
+    ).indented()
+    lint()
+      .files(androidTextStubs, testFile)
+      .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `visitBinaryExpression - given violating expression with INCLUSIVE_INCLUSIVE on left - creates error and fix`() {
+    testViolatingExpressionLeft("Spanned.SPAN_INCLUSIVE_INCLUSIVE")
+  }
+
+  @Test
+  fun `visitBinaryExpression - given violating expression with INCLUSIVE_EXCLUSIVE on left - creates error and fix`() {
+    testViolatingExpressionLeft("Spanned.SPAN_INCLUSIVE_EXCLUSIVE")
+  }
+
+  @Test
+  fun `visitBinaryExpression - given violating expression with EXCLUSIVE_INCLUSIVE on left - creates error and fix`() {
+    testViolatingExpressionLeft("Spanned.SPAN_EXCLUSIVE_INCLUSIVE")
+  }
+
+  @Test
+  fun `visitBinaryExpression - given violating expression with EXCLUSIVE_EXCLUSIVE on left - creates error and fix`() {
+    testViolatingExpressionLeft("Spanned.SPAN_EXCLUSIVE_EXCLUSIVE")
+  }
+
+  private fun testViolatingExpressionLeft(markPoint: String) {
+    @Language("kotlin")
+    val testFile = kotlin(
+      """
+                package slack.text
+
+              import android.text.Spanned
+
+              class MyClass {
+                  fun doCheckIncorrectly(spanned: Spanned): Boolean {
+                    return spanned.getSpanFlags(Object()) == $markPoint || Spanned.x()
+                  }
+              }
+            """
+    ).indented()
+    lint()
+      .files(androidTextStubs, testFile)
+      .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+      .run()
+      .expect(
+        """
+          src/slack/text/MyClass.kt:7: Error: Do not check against $markPoint directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                return spanned.getSpanFlags(Object()) == $markPoint || Spanned.x()
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+          Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
+          @@ -7 +7
+          -       return spanned.getSpanFlags(Object()) == $markPoint || Spanned.x()
+          +       return ((spanned.getSpanFlags(Object())) and android.text.Spanned.SPAN_POINT_MARK_MASK) == $markPoint || Spanned.x()
+        """.trimIndent()
+      )
+  }
+
+  @Test
+  fun `visitBinaryExpression - given violating expression with INCLUSIVE_INCLUSIVE on right - creates error and fix`() {
+    testViolatingExpressionRight("SPAN_INCLUSIVE_INCLUSIVE")
+  }
+
+  @Test
+  fun `visitBinaryExpression - given violating expression with INCLUSIVE_EXCLUSIVE on right - creates error and fix`() {
+    testViolatingExpressionRight("SPAN_INCLUSIVE_EXCLUSIVE")
+  }
+
+  @Test
+  fun `visitBinaryExpression - given violating expression with EXCLUSIVE_INCLUSIVE on right - creates error and fix`() {
+    testViolatingExpressionRight("SPAN_EXCLUSIVE_INCLUSIVE")
+  }
+
+  @Test
+  fun `visitBinaryExpression - given violating expression with EXCLUSIVE_EXCLUSIVE on right - creates error and fix`() {
+    testViolatingExpressionRight("SPAN_EXCLUSIVE_EXCLUSIVE")
+  }
+
+  private fun testViolatingExpressionRight(markPoint: String) {
+    @Language("kotlin")
+    val testFile = kotlin(
+      """
+                package slack.text
+
+              import android.text.Spanned.$markPoint
+
+              class MyClass {
+                  fun doCheckIncorrectly(spanned: Spanned): Boolean {
+                    return $markPoint == spanned.getSpanFlags(Object()) || isBoolean1() && isBoolean2()
+                  }
+              }
+            """
+    ).indented()
+    lint()
+      .files(androidTextStubs, testFile)
+      .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+      .run()
+      .expect(
+        """
+          src/slack/text/MyClass.kt:7: Error: Do not check against $markPoint directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                return $markPoint == spanned.getSpanFlags(Object()) || isBoolean1() && isBoolean2()
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          1 errors, 0 warnings
+        """.trimIndent()
+      )
+      .expectFixDiffs(
+        """
+          Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
+          @@ -7 +7
+          -       return $markPoint == spanned.getSpanFlags(Object()) || isBoolean1() && isBoolean2()
+          +       return $markPoint == ((spanned.getSpanFlags(Object())) and android.text.Spanned.SPAN_POINT_MARK_MASK) || isBoolean1() && isBoolean2()
+        """.trimIndent()
+      )
+  }
 }

--- a/slack-lint/src/test/java/slack/lint/text/SpanPointMarkDangerousCheckDetectorTest.kt
+++ b/slack-lint/src/test/java/slack/lint/text/SpanPointMarkDangerousCheckDetectorTest.kt
@@ -1,0 +1,165 @@
+package slack.lint.text
+
+import org.intellij.lang.annotations.Language
+import org.junit.Assert.*
+import org.junit.Test
+import slack.lint.BaseSlackLintTest
+import slack.lint.rx.RxSubscribeOnMainDetector
+import slack.lint.rx.rxJavaJar3
+
+class SpanPointMarkDangerousCheckDetectorTest : BaseSlackLintTest() {
+
+    override fun getDetector() = SpanPointMarkDangerousCheckDetector()
+    override fun getIssues() = listOf(SpanPointMarkDangerousCheckDetector.ISSUE)
+
+    @Test
+    fun `visitBinaryExpression - given violating file with equality and flag on right - creates error and fix`() {
+        @Language("kotlin")
+        val testFile = kotlin(
+            """
+                package slack.text
+        
+              import android.text.Spanned
+        
+              class MyClass {
+                  fun doCheck(spanned: Spanned): Boolean {
+                    return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                  }
+              }
+            """
+        ).indented()
+        lint()
+            .files(testFile)
+            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                      return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent()
+            )
+            .expectFixDiffs(
+                """
+                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
+                @@ -7 +7
+                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                """.trimIndent()
+            )
+    }
+    @Test
+    fun `visitBinaryExpression - given violating file with equality and flag on left - creates error and fix`() {
+        @Language("kotlin")
+        val testFile = kotlin(
+            """
+                package slack.text
+        
+              import android.text.Spanned
+        
+              class MyClass {
+                  fun doCheck(spanned: Spanned): Boolean {
+                    return Spanned.INCLUSIVE_INCLUSIVE == spanned.getSpanFlags(Object()) || Spanned.x()
+                  }
+              }
+            """
+        ).indented()
+        lint()
+            .files(testFile)
+            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                      return Spanned.INCLUSIVE_INCLUSIVE == spanned.getSpanFlags(Object()) || Spanned.x()
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent()
+            )
+            .expectFixDiffs(
+                """
+                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
+                @@ -7 +7
+                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `visitBinaryExpression - given violating file with inequality and flag on right - creates error and fix`() {
+        @Language("kotlin")
+        val testFile = kotlin(
+            """
+                package slack.text
+        
+              import android.text.Spanned
+        
+              class MyClass {
+                  fun doCheck(spanned: Spanned): Boolean {
+                    return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                  }
+              }
+            """
+        ).indented()
+        lint()
+            .files(testFile)
+            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                      return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent()
+            )
+            .expectFixDiffs(
+                """
+                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
+                @@ -7 +7
+                -       return spanned.getSpanFlags(Object()) != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK != Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `visitBinaryExpression - given violating file with inequality and flag on left - creates error and fix`() {
+        @Language("kotlin")
+        val testFile = kotlin(
+            """
+                package slack.text
+        
+              import android.text.Spanned
+        
+              class MyClass {
+                  fun doCheck(spanned: Spanned): Boolean {
+                    return Spanned.INCLUSIVE_INCLUSIVE != spanned.getSpanFlags(Object()) || Spanned.x()
+                  }
+              }
+            """
+        ).indented()
+        lint()
+            .files(testFile)
+            .issues(SpanPointMarkDangerousCheckDetector.ISSUE)
+            .run()
+            .expect(
+                """
+                src/slack/text/MyClass.kt:7: Error: Do not check against Spanned.INCLUSIVE_INCLUSIVE directly. Instead mask flag with Spanned.SPAN_POINT_MARK_MASK to only check MARK_POINT flags. [SpanPointMarkDangerousCheck]
+                      return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent()
+            )
+            .expectFixDiffs(
+                """
+                Fix for src/slack/text/MyClass.kt line 7: Use bitwise mask:
+                @@ -7 +7
+                -       return spanned.getSpanFlags(Object()) == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                +       return (spanned.getSpanFlags(Object()) ) and Spanned.SPAN_POINT_MARK_MASK == Spanned.INCLUSIVE_INCLUSIVE || Spanned.x()
+                """.trimIndent()
+            )
+    }
+}


### PR DESCRIPTION
###  Summary

Spans flags can have priority or other bits set. Ensure that Span flags are checked using `currentFlag and Spanned.SPAN_POINT_MARK_MASK == desiredFlag` rather than just `currentFlag == desiredFlag` 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

> The following point can be removed after setting up CI (such as Travis) with coverage reports (such as Codecov)

* [x] I've written tests to cover the new code and functionality included in this PR.

> The following point can be removed after setting up a CLA reporting tool such as cla-assistant.io

* [x] I've read, agree to, and signed the [Contributor License Agreement (CLA)](https://cla-assistant.io/{project_slug}).
